### PR TITLE
updating version of unstructured

### DIFF
--- a/Chat_With_Any_Document.ipynb
+++ b/Chat_With_Any_Document.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "%%bash \n",
     "\n",
-    "pip -q install langchain faiss-cpu unstructured\n",
+    "pip -q install langchain faiss-cpu unstructured==0.7.12\n",
     "pip -q install openai tiktoken\n",
     "pip -q install pytesseract pypdf"
    ]


### PR DESCRIPTION
apparently it changed! But downgrading to this version works. For maximum repeatability, you should probably be specifying versions for all package installs. :) 

Take a look at `pip freeze` or `pipeqs`.